### PR TITLE
fixes for cargonize branch

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,10 @@ authors = ["KENZ.gelsoft@gmail.com"]
 
 build = "build.rs"
 
+[dependencies] 
+libc = "0.1.*"
+
 [build-dependencies]
-gcc = "0.3.5"
-bindgen = "0.14"
+gcc = "0.3.*"
+bindgen = "0.15.*"
+

--- a/build.rs
+++ b/build.rs
@@ -242,6 +242,14 @@ fn generate_unsafe_rs() {
 		bindings.clang_arg(*flag);
 	}
 
+    match bindgen::get_include_dir() {
+        Some(path) => {
+            bindings.clang_arg("-I");
+            bindings.clang_arg(path);
+        }
+        None => (),
+    }
+
     bindings.match_pat("wxc");
 
     let binding = bindings.generate().unwrap();

--- a/build.rs
+++ b/build.rs
@@ -1,19 +1,56 @@
 use std::env;
+use std::fs;
 use std::fs::File;
 use std::io::Write;
 use std::path::Path;
 use std::process::Command;
 
 extern crate gcc;
+extern crate bindgen;
 
 fn main() {
+    update_submodules();
+    patch_wxc_glue();
 	build_libwxc();
-	build_bindgen();
+    export_linker_flags();
 	generate_unsafe_rs();
 	generate_other_rs();
 }
 
+fn update_submodules() {
+    println!("build.rs : update submodules");
+
+    let curr_dir_str = env::var("CARGO_MANIFEST_DIR").unwrap();
+    let curr_dir = Path::new(&curr_dir_str);
+    Command::new("git").arg("submodule").arg("update").arg("--init")
+        .current_dir(&curr_dir).status().unwrap();
+
+    println!("build.rs : update submodules - done");
+}
+
+fn path_exists(path: &Path) -> bool {
+    match fs::metadata(path) {
+        Ok(_) => true,
+        Err(_) => false
+    }
+}
+
 fn build_libwxc() {
+    println!("build.rs : check if libwxc already exists");
+
+    let out_dir = env::var("OUT_DIR").unwrap();
+    let dest_path = Path::new(&out_dir).join("libwxc.a");
+    if path_exists(&dest_path) {
+        //no need to rebuild libwxc.a
+        //just export linker flags
+        println!("cargo:rustc-link-search=native={}", &out_dir);
+        println!("cargo:rustc-link-lib=static=wxc");
+        println!("build.rs : libwxc already exists");
+        return;
+    }
+
+    println!("build.rs : build libwxc");
+
 	let files = vec![
 		"apppath.cpp", 
 		"dragimage.cpp", 
@@ -126,7 +163,7 @@ fn build_libwxc() {
 	];
 
 	let mut config = gcc::Config::new();
-	for flag in wx_config("--cxxflags").split_whitespace() {
+	for flag in wx_config(&["--cxxflags"]).split_whitespace() {
 		config.flag(flag);
 	}
 	for file in files {
@@ -134,56 +171,116 @@ fn build_libwxc() {
 	}
 	config
 		.include("wxHaskell/wxc/src/include")
-		.compile("libwxc.a")
+		.compile("libwxc.a");
+
+    println!("build.rs : build libwxc - done");
 }
 
-fn wx_config(config: &str) -> String {
+fn wx_config(args: &[&str]) -> String {
 	let output = Command::new("wx-config")
-		.arg(config)
+		.args(args)
 		.output()
 		.unwrap();
 	let flags = String::from_utf8_lossy(&output.stdout);
 	flags.to_string()
 }
 
-fn build_bindgen() {
-	Command::new("cargo")
-		.current_dir("rust-bindgen/")
-		.arg("build")
-		.status()
-		.unwrap_or_else(|e| {
-		    panic!("failed to build bindgen: {}", e)
-		});
+fn export_linker_flags() {
+    println!("build.rs : export global linker flags");
+
+    //returns some like 
+    //-L/usr/lib64 -pthread   -lwx_gtk2u_xrc-3.0 -lwx_gtk2u_webview-3.0 -lwx_gtk2u_stc-3.0
+    //-lwx_gtk2u_richtext-3.0 -lwx_gtk2u_ribbon-3.0 -lwx_gtk2u_propgrid-3.0 -lwx_gtk2u_aui-3.0
+    //-lwx_gtk2u_gl-3.0 -lwx_gtk2u_media-3.0 -lwx_gtk2u_html-3.0 -lwx_gtk2u_qa-3.0
+    //-lwx_gtk2u_adv-3.0 -lwx_gtk2u_core-3.0 -lwx_baseu_xml-3.0 -lwx_baseu_net-3.0 -lwx_baseu-3.0
+	for flag in wx_config(&["--libs", "all"]).split_whitespace() {
+		if flag.starts_with("-L") {
+            println!("cargo:rustc-link-search=native={}", &flag[2..]);
+        } else if flag.starts_with("-l") {
+            println!("cargo:rustc-link-lib=dylib={}", &flag[2..]);
+        }
+	}
+    println!("cargo:rustc-link-lib=dylib=stdc++");
+
+    println!("build.rs : export global linker flags - done");
+}
+
+
+struct BindgenLogger;
+
+impl bindgen::Logger for BindgenLogger {
+    fn error(&self, msg: &str) {
+        println!("bindgen error:  {}", msg);
+    }
+
+    fn warn(&self, msg: &str) {
+        println!("bindgen warning: {}", msg);
+    }
 }
 
 fn generate_unsafe_rs() {
-	let mut command = Command::new("rust-bindgen/target/debug/bindgen");
-	command
-		.args(&[
-			"-allow-unknown-types",
-			"-x", "c++",
-		]);
-	for flag in wx_config("--cppflags").split_whitespace() {
-		command.arg(flag);
+    println!("build.rs : generate unsafe rs");
+
+    let logger = BindgenLogger;
+    let mut bindings = bindgen::builder();
+    bindings.forbid_unknown_types();
+    bindings.log(&logger);
+
+    
+	for flag in wx_config(&["--cxxflags"]).split_whitespace() {
+		bindings.clang_arg(flag);
 	}
-	let output = command
-		.args(&[
-			"--include", "stdint.h",
-			"--include", "time.h",
-			"wxHaskell/wxc/src/include/wxc.h"
-		])
-		.output()
-		.unwrap();
+
+    let args = [
+        "-x", "c++", 
+        "--include", "stdint.h",
+        "--include", "time.h",
+        "wxHaskell/wxc/src/include/wxc.h"
+    ];
+
+	for flag in args.iter() {
+		bindings.clang_arg(*flag);
+	}
+
+    bindings.match_pat("wxc");
+
+    let binding = bindings.generate().unwrap();
+
 	let root_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
-	let unsafe_rs = Path::new(&root_dir).join("_unsafe.rs");
+	let unsafe_rs = Path::new(&root_dir).join("src").join("_unsafe.rs");
 	let mut file = File::create(&unsafe_rs).unwrap();
-	
-	file.write_all(&output.stdout).unwrap();
+
+    file.write_all("/* added by build.rs */\n".as_bytes()).unwrap();
+    file.write_all("use libc::*;\n\n".as_bytes()).unwrap();
+
+    binding.write(Box::new(file)).unwrap();
+    
+    println!("build.rs : generate unsafe rs - done");
+}
+
+fn patch_wxc_glue() {
+    println!("build.rs : patching wxHaskell/wxc/src/include/wxc_glue.h");
+
+    //patch -N -p1 -i ../wxc/wxc_glue_h.patch
+	let root_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
+	let wxhaskel_dir = Path::new(&root_dir).join("wxHaskell");
+
+	Command::new("patch")
+        .current_dir(wxhaskel_dir)
+		.args(&["-N", "-p1", "-i", "../wxc/wxc_glue_h.patch"])
+		.status()
+		.unwrap();
+
+    println!("build.rs : patching wxHaskell/wxc/src/include/wxc_glue.h - done");
 }
 
 fn generate_other_rs() {
+    println!("build.rs : running src/codegen.py");
+
 	Command::new("python")
 		.args(&["src/codegen.py", "wxHaskell/wxc/src/include/wxc.h"])
 		.status()
 		.unwrap();
+
+    println!("build.rs : running src/codegen.py - done");
 }

--- a/src/defs.rs
+++ b/src/defs.rs
@@ -26,7 +26,7 @@ pub const DEFAULT_FRAME_STYLE: c_int =
 
 // manually converted from defs.h
 
-pub const VSCROLL: c_int = 0x80000000;
+pub const VSCROLL: c_int = -2147483648; //0x80000000;
 pub const HSCROLL: c_int = 0x40000000;
 pub const CAPTION: c_int = 0x20000000;
 
@@ -148,7 +148,7 @@ pub const CLOSE: c_int = 0x00000040;
 pub const OK_DEFAULT: c_int = 0x00000000;
 pub const YES_DEFAULT: c_int = 0x00000000;
 pub const NO_DEFAULT: c_int = 0x00000080;
-pub const CANCEL_DEFAULT: c_int = 0x80000000;
+pub const CANCEL_DEFAULT: c_int = -2147483648; //0x80000000;
 
 pub const ICON_EXCLAMATION: c_int = 0x00000100;
 pub const ICON_HAND: c_int = 0x00000200;
@@ -175,7 +175,10 @@ pub const ICON_MASK: c_int =
 pub const P_ALL: c_int = 0;
 pub const P_PID: c_int = 1;
 pub const P_PGID: c_int = 2;
+
+#[allow(non_upper_case_globals)]
 pub const DefaultCoord: c_int = -1;
+
 pub const CENTRE: c_int = 1;
 pub const CENTER: c_int = 1;
 pub const HORIZONTAL: c_int = 4;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,6 @@
 #![crate_name="wx"]
 #![crate_type="lib"]
 
-#![feature(libc)]
-
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]
 

--- a/tests/macros.rs
+++ b/tests/macros.rs
@@ -2,8 +2,7 @@
 
 macro_rules! wxApp(
     ($f: ident) => (
-        #[start]
-        fn start(argc: isize, argv: *const *const u8) -> isize {
+        fn main() {
             use libc::c_void;
 
             use wx::base::Closure;
@@ -14,7 +13,6 @@ macro_rules! wxApp(
             let closure = Closure::new($f as *mut c_void, NULLPTR);
             let args: Vec<*mut i32> = Vec::new();
             RustApp::initializeC(&closure, args.len() as i32, args.as_ptr() as *mut *mut i8);
-            0
         }
     )
 );

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,7 +1,4 @@
-#![crate_name = "test"]
-
-#![feature(libc)]
-#![feature(start)]
+//#![crate_name = "test"]
 
 extern crate libc;
 extern crate wx;
@@ -15,6 +12,22 @@ use wx::core::*;
 
 mod macros;
 
+
+
+#[test]
+fn hello_test() {
+    const NULLPTR: *mut c_void = 0 as *mut c_void;
+
+    let closure = Closure::new(wx_main_not_show as *mut c_void, NULLPTR);
+    let args: Vec<*mut i32> = Vec::new();
+    RustApp::initializeC(&closure, args.len() as i32, args.as_ptr() as *mut *mut i8);
+}
+
+extern "C"
+fn wx_main_not_show() {
+    let frame = make_frame();
+    frame.destroy();
+}
 
 wxApp!(wx_main);
 


### PR DESCRIPTION
make things work :
 - update dependencies
 - Make build script usable
   - logs
   - updates git submodules
   - doesn't rebuild libwxc.a if already exists
   - exports linker flags for wx widgets (wx-config --libs all)
   - uses recent bindgen as library
   - patches wxHaskell/wxc/src/include/wxc_glue.h (like cmake)
 - fix warnings/errors at compilation time
 - test is run via 'build test' without gui

tested at OpenSUSE 13.2